### PR TITLE
Added raw data + added Party Add on page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 bailys.sln
 bailys.v12.suo
+bailysStart.bat

--- a/.settings/launch.json
+++ b/.settings/launch.json
@@ -1,0 +1,38 @@
+{
+	"version": "0.1.0",
+	// List of configurations. Add new configurations or edit existing ones.  
+	// ONLY "node" and "mono" are supported, change "type" to switch.
+	"configurations": [
+		{
+			// Name of configuration; appears in the launch configuration drop down menu.
+			"name": "Launch app.js",
+			// Type of configuration. Possible values: "node", "mono".
+			"type": "node",
+			// Workspace relative or absolute path to the program.
+			"program": "app.js",
+			// Automatically stop program after launch.
+			"stopOnEntry": true,
+			// Command line arguments passed to the program.
+			"args": [],
+			// Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.
+			"cwd": ".",
+			// Workspace relative or absolute path to the runtime executable to be used. Default is the runtime executable on the PATH.
+			"runtimeExecutable": null,
+			// Optional arguments passed to the runtime executable.
+			"runtimeArguments": [],
+			// Environment variables passed to the program.
+			"env": { },
+			// Use JavaScript source maps (if they exist).
+			"sourceMaps": false
+		}, 
+		{
+			"name": "Attach",
+			"type": "node",
+			// TCP/IP address. Default is "localhost".
+			"address": "localhost",
+			// Port to attach to.
+			"port": 5858,
+			"sourceMaps": false
+		}
+	]
+}

--- a/bailysStart.bat
+++ b/bailysStart.bat
@@ -1,4 +1,4 @@
 
 cd\
-cd\development\bailys
+cd C:\Users\Michael\Documents\development\bailys
 start nodemon .\bin\www

--- a/server/controllers/banquets/partyAddonsController.js
+++ b/server/controllers/banquets/partyAddonsController.js
@@ -1,0 +1,23 @@
+var banquetsService = require('../../services/banquetsService');
+
+
+
+
+
+
+var getData = function (req, res) {
+
+    var viewBag = {};
+    viewBag.title = "Party Add-ons";
+    banquetsService.getFutureBookings()
+        .then(function(banquets){
+            viewBag.banquets = banquets;
+            res.render('banquets/partyaddons', {  viewBag: viewBag })
+        });
+
+
+};
+
+
+
+exports.getView = getData;

--- a/server/includes/nav.jade
+++ b/server/includes/nav.jade
@@ -62,6 +62,8 @@
                             a(href='/banquets/menus') Menus
                         li
                             a(href='/banquets/beveragepackages') Beverage Packages
+                        li
+                            a(href='/banquets/partyaddons') Party Add-ons
                 li.dropdown
                     a.dropdown-toggle(href='#' data-toggle="dropdown") About
                         span.caret

--- a/server/includes/navBanquet.jade
+++ b/server/includes/navBanquet.jade
@@ -12,5 +12,7 @@
                 a(href="/banquets/menus") Menus
             li
                 a(href="/banquets/beveragepackages") Beverage Packages
+            li
+                a(href="/banquets/partyaddons") Party Add-ons
             
 

--- a/server/routes/banquets.js
+++ b/server/routes/banquets.js
@@ -8,6 +8,7 @@ var banquetMenusController = require('../controllers/banquets/banquetMenusContro
 var beveragePackageController = require('../controllers/banquets/beveragePackageController');
 var venuesController = require('../controllers/banquets/venuesController');
 var bookingController = require('../controllers/banquets/bookingController');
+var partyAddonsController = require('../controllers/banquets/partyAddonsController');
 
 router.get('/', banquetsController.getView);
 
@@ -17,6 +18,8 @@ router.get('/booking', bookingController.getView);
 router.get('/menus', banquetMenusController.getView);
 
 router.get('/beveragepackages', beveragePackageController.getView);
+
+router.get('/partyAddons', partyAddonsController.getView);
 
 
 

--- a/server/views/banquets/banquetmenus.jade
+++ b/server/views/banquets/banquetmenus.jade
@@ -1,3 +1,155 @@
 ﻿extends ../../includes/layoutBanquet
 block banquetContent
-    p Here is the banquet menus landing page information!
+    h3 Breakfast Banquets
+
+    p Breakfast banquets are perfect for early morning business meeting, fueling up for a day in Old Town or Wine Country, or enjoying friends and family the
+        | morning after a big wedding.
+
+    p Banquets may start as early as 7:30am and can be extended into an all day event when lunch and dinner options are purchased.
+
+    p Buffet and Plate Service breakfasts make ordering easy. Just tell us the number of people in the party and your event is planned. 
+        | Custom menus allow more flexibility and creativity on your part. Remember, upgrade selections, including audio/visual equipment, can be found
+        a (href = ) here 
+        | if you would like to enhance your party.
+
+    p Currently the normal food and beverage minimums do not apply to breakfast banquets. However a minimum of 10 people are required to book a party.
+ 
+    h1 REMAINING PAGE INFORMATION COMMENTED OUT IN BANQUETMENUS.JADE. THIS NEEDS TO BE TABLE FORMATED AND IS BEYOND MY CURRENT ABILITY
+ <!--   
+Pre-Composed Menus
+       
+Buffets
+     
+    
+        
+Continental Breakfast #1	
+$10.95
+    
+Croissants, Fruit Platter, Orange Juice, Coffee Station
+Continental Breakfast #2	
+ 
+ 
+$12.95
+Assorted Pastries, Fruit Platter, Assorted Yogurts, Orange Juice, Coffee Station
+Breakfast Buffet #1	
+ 
+$12.95
+Scrambled Eggs, Bacon, Home Style Potatoes, Orange Juice, Coffee Station
+Breakfast Buffet #2	
+ 
+$16.95
+Grilled Vegetable Frittata, Bacon and Sausage, Home Style Potatoes, Assorted Pastries, Fruit Platter, Orange Juice, Coffee Station
+
+Plate Service
+Sunrise Splendor	
+ 
+$12.95
+Grilled Vegetable Frittata Served with Bacon & Home Style Potatoes | Orange Juice and Coffee Service
+Celebration Brunch (2 course)	
+ 
+$14.95
+Fruit & Pastry Sampler | Eggs Benedict or Vegetable Omelet Served with Bacon & Home Style Potatoes | Orange Juice and Coffee Service
+
+ 
+Custom Menu
+Starter
+Fruit and Pastry Sampler	
+ 
+$5.95
+Fresh seasonal fruit served with assorted mini pastries
+Cinnamon Roll	
+ 
+$2.95
+Fresh baked cinnamon roll topped with vanilla icing
+
+Entrees
+Choose up to three.
+Vegetable Omelet	
+ 
+$8.95
+Roasted red peppers, artichoke hearts, sauteed onions and zuchinni in a large three egg omelet
+Mushroom, Spinach and Cheese Omelet	
+ 
+$8.95
+Sauteed spinach and mushrooms and melted fresh mozzarella
+California Omelet	
+ 
+$11.95
+Sauteed chicken breast, green onion, and avocado topped with hollandaise
+Huevos Rancheros	
+ 
+$9.95
+Two eggs over easy served on a crisp corn tortilla, finished with a homemade ranchero sauce, served with Spanish rice and refried beans
+Cinnamon Dolce French Toast	
+ 
+$7.95
+Fluffy egg bread with a cinnamon and nutmeg batter, finished with warm caramel sauce
+Canadian Bacon Eggs Benedict	
+ 
+$10.95
+Two poached eggs served on English muffins with Canadian Bacon topped with homemade Hollandaise sauce
+Baked Ham & Eggs	
+ 
+$11.95
+Generous portion of honey baked ham served with two eggs cooked to order (entire party must have eggs cooked same)
+New York Steak & Eggs	
+ 
+$13.95
+Grilled New York steak, served aside two eggs cooked to order (entire party must have eggs cooked same way)
+
+Side Dishes
+To accompany the above entrees, choose 2 side dishes for you entire party.
+Bacon (4ea)	
+ 
+ included
+Sausage (2ea)	
+ 
+ included
+Bacon and Sausage  (2ea/1ea)	
+ 
+ included
+Biscuit & Gravy	
+ 
+ included
+Fruit Kabob	
+ 
+ included
+Hash Browns	
+ 
+ included
+Homestyle Potatoes	
+ 
+ included
+
+Beverages
+Coffee Service	
+ 
+$2.95
+Choice of Coffee or Decaffeinated Coffee
+Orange Juice (6oz)	
+ 
+$2.95
+Fresh Orange Juice
+
+Adult Beverages
+//Mimosa	
+ 
+$6.50
+Champagne and orange juice cocktail
+Red Beer	
+ 
+$4.00
+Bud Lite and tomato juice
+Bloody Mary	
+ 
+$6.50
+Our house bloody mary mix, vodka, garnished with seasoned salt and celery
+Harvey Wallbanger	
+ 
+$6.00
+Galliano and orange juice
+Bailey's and Coffee	
+ 
+$6.00
+Hot coffee with Bailey's Irish Cream topped with whipped cream
+-->

--- a/server/views/banquets/beveragepackages.jade
+++ b/server/views/banquets/beveragepackages.jade
@@ -1,3 +1,62 @@
 ﻿extends ../../includes/layoutBanquet
 block banquetContent
-    p Here is beverage package information!
+    p Here is beverage package information! -- MORE IN COMMENTS
+
+// Beverage Service
+
+// For quick speed of service we suggest limiting the number of choices of beverages. The choices you offer can be made during the planning process. Listed below are several of our best value selections. Please visit our website for the full list.
+
+// All beverages and cocktails are always available through our service staff. However, preparation times may vary during busy periods. If you are concerned about long drink service times, you may provide a bar for your guests for a designated set up fee. Note that this set up fee is not included in the minimum food and beverage minimums.
+
+// Bar Service Set Up Fee	
+ 
+// $150.00
+// Allows your guests the extra service of a bartender in your area. Fully stocked bar. No blended drinks. Pay for what drinks you consume.
+// Banquet Wines (750ml)
+// House White	
+ 
+// $24.00 and up
+// House Red	
+ 
+// $30.00 and up
+// Banquet Beers
+// Bub Light 16oz	
+ 
+// $5.50
+// Budwieser 16oz	
+ 
+// $5.50
+// Coors Light 16oz	
+ 
+// $5.50
+// Corona Extra	
+ 
+// $4.00
+// Blue Moon	
+ 
+// $4.50
+// Kona Firerock Pale Ale	
+ 
+// $4.00
+// Green Flash Hop Head Red IPA	
+ 
+// $4.50
+// St. Pauli Girl N/A	
+ 
+// $3.50
+ 
+ 
+// Non Alcoholic Beverages
+// Self Serve Coffee Station	
+ 
+// $2.50
+// Coffee Service	
+ 
+// $2.95
+// Iced Tea Station	
+ 
+// $2.95
+// N/A Beverage Service	
+ 
+// $2.95
+ 

--- a/server/views/banquets/booking.jade
+++ b/server/views/banquets/booking.jade
@@ -1,6 +1,84 @@
 ﻿extends ../../includes/layoutBanquet
 block banquetContent
-    p Here is the booking information!
+
+    h1 Booking Information REMAINING INFO COMMENTED OUT
+
+<!--
+Step One - Make a Reservation
+Select a date and start time for your event.  Parties are continuously booked throughout the year on a first come first served basis.  The month of December is especially busy. You can check availability in the side bar on the right. 
+
+Your event must begin and end within the following meal periods.
+
+Breakfast 9:00am - 1:00pm
+
+Lunch 11:00am - 4:00pm
+
+Dinner 5:00pm - 9:30pm
+
+Nightclub 10:00pm - 2:00am
+
+To book an event, a non-refundable deposit of $100 (cash or credit card) will be required. At this time the Events Manager can answer any questions you may have.
+
+Step Two - Select Your Menu Items
+As a general rule, our pre-composed menus provide the most value and simplify the menu selection process.
+
+For custom menus, determine the number of courses you would like for your meal (two course minimum). Select the items in each course from the appropriate menu (menus are not interchangeable). Below each menu section title is the number of selections to make per course.
+
+If required, wine selections may be made to match your budget and taste. The full wine list is available on the website. If you care to bring in wine that we do not offer on our wine list we charge a $15.00 corkage fee per 750ml bottle.
+
+Step Three - Call to finalize the details
+To ensure ingredient availability, call the events manager 10 days prior to the event to formalize the menu selections and your guaranteed guest count. If you would like printed personalized menus share the exact text with the Events Manager. We will email or fax the contract for your review and approval. Sign the contract acknowledging you agree upon the minimum food and beverage amount, the menu selections, and the guaranteed number of people.
+
+Room Minimum & Capacity
+Room Name	 Lunch	 Dinner	 Capacity 
+FSB&G Entire Patio 	$1000	$1500 Sun-Thu
+$2200 Fri-Sat	31-68 
+FSB&G Portion of Patio	No minimum. 
+Patio remains open to the public for normal business.	No minimum. 
+Patio remains open to the public for normal business.	16-30   
+Baily's North Dining Room	$800	
+$1500 Sun - Thu
+$1800 Fri - Sat 
+50    
+ 
+Baily's South Dining Room 	$300	$400 Sun - Thu
+$500 Fri - Sat	18   
+Baily's Rotunda	$750 (Sat & Sun only) 	
+$1800 Sun - Thu
+$2100 Fri - Sat 
+38    
+ 
+Baily's Balcony 	$500 	
+$800 Sun - Thu
+$1100 Fri - Sat 
+30 
+* Call for HOLIDAY RATES during the month of DECEMBER
+Other Considerations
+
+Getting in Touch with Us
+Based on business requirements, our Events Manager keeps flexible daytime hours Monday - Friday.  You may contact the Events Manager at 951-676-9567 ext. 107.  Always leave a voice mail for a prompt return call no later than the end of the next business day.
+
+Email (events@oldtowndining.com) is great way to document the inevitable back and forth dialog that occurs as we plan your event. 
+
+Additionally, last minute minor changes, such as a late arrival or a variation in number of guests, can be handled by a dining room manager.  Just dial 951-676-9567 for such occurrences.
+
+Table Configurations
+Our staff is trained to accommodate special table configurations.  However, because of room capacities and the availability of tables and chairs we may be unable to facilitate special requests.  In some of these cases accommodations can be made with the rental of additional equipment at the expense of the client.
+
+End Time
+Please keep in mind the “end time” of your party.  Due to consecutive bookings during peak times (Friday and Saturday), we require that guests adhere to the end time of their party.  This allows our staff to prepare the room for subsequent events.  You will be charged a late fee of $50.00 if your party exceeds the end time by more than 10 minutes.
+
+Payments & Billing
+A 50% installment will be required a week prior to your event.
+
+Your final bill will be the tally of all food and beverage charged at the contracted/menu price.  All purchases are subject to sales tax and a 20% service charge.  If the tally does not meet the food and beverage minimum the difference will be billed as a room charge and/or unmet minimum.
+
+If your bill exceeds the minimum food and beverage charge as defined above, then you will be charged the actual amount of the food and beverage purchases, plus tax and a 20% service charge.
+
+Payment for any rentals, which are coordinated by the Events Manager, will be paid in full (including tax on the rentals) two weeks prior to the event.
+
+ 
     div#dataHere
     
         
+--!>

--- a/server/views/banquets/partyaddons.jade
+++ b/server/views/banquets/partyaddons.jade
@@ -1,0 +1,136 @@
+extends ../../includes/layoutBanquet
+block banquetContent
+	h1 Here is the add on information -- MORE IN COMMENTS
+	
+// 	Party Add-Ons
+
+// We offer a variety of hors d' oeuvres and desserts to further enhance your banquet.  Addtionally, we make avaialable several frequently requested rental items.  The sections below describe each.
+ 
+// Hors d' Oeuvres Receptions
+// When booking an entire room hors d’ oeuvres will be presented as an elegant self serve buffet available at the designated start time for your party. Receptions last approximately 20 minutes depending on your guest’s arrival. As alternate options, h
+// Samplers
+// Select no more than two.
+// Vegetable Fruit and Cheese (not available for plated course)	
+ 
+// $6.95
+// Crudite platter with herbed ranch dip, served with assorted cheeses and crackers and fresh seasonal fruit
+// Appetizer Sampler	
+ 
+// $8.95
+// Asparagus Bruschetta, Mushroom Drops, Chicken Satay
+// Canape Sampler	
+ 
+// $8.95
+// Assortment of Tenderloin, Smoked Salmon, Curry Chicken Canapes (see a la carte menu for full description)
+
+// Canapes and Small Bites
+// The items below are sold by the piece. We recommend 4-6 pieces per person. Select no more than three.
+// Shrimp Cocktail	
+ 
+// $1.65
+// Fresh tiger shrimp poached in court bouillon served with homemade cocktail sauce
+// Caprese Skewers	
+ 
+// $1.70
+// Cherry tomatoes and fresh mozzarella skewered with basil leaves and drizzled with balsamic reduction
+// Tenderloin Canape	
+ 
+// $1.75
+// Bruschetta topped with herb roasted tenderloin and finished with a gorgonzola and mascarpone mousse
+// Smoked Salmon Canapes	
+ 
+// $1.65
+// Smoked salmon mousse served on a toast point garnished with a caper and a sprig of dill
+// Curry Chicken Salad Canape	
+ 
+// $1.35
+// Grilled chicken tossed with a light curry mayonnaise, red seedless grapes and cashews served on a sour dough toast point
+// Mushroom Drops	
+ 
+// $1.65
+// Crimini mushrooms stuffed with jalapeno and cream cheese, wrapped in a won ton and fried, served with a Teriyaki dipping sauce
+// Chicken Satay	
+ 
+// $1.75
+// Skewered and grilled chicken breast, served with a Thai peanut sauce
+// Tempura Artichoke Hearts	
+ 
+// $1.50
+// Tender artichoke hearts dipped in tempura batter and deep fried, served with a soy aioli
+// Smoked Duck Spring Rolls	
+ 
+// $1.75
+// Sautéed vegetables and smoked duck wrapped in an egg roll wrapper, fried and finished with a honey wasabi mustard
+// Shrimp Turnover	
+ 
+// $1.65
+// Tiger shrimp wrapped in puff pastry and finished with an herbed lemon tartar sauce
+// Asparagus Bruschetta	
+ 
+// $1.75
+// Grilled asparagus on toasted ciabatta with melted smoked mozzarella cheese, tomato concasse and balsamic reduction
+
+ 
+// Desserts
+// Plate Service Desserts
+// Select 1 item for entire party.
+// Creme Brulee	
+ 
+// $6.95
+// One of our most famous desserts, a rich custard topped with caramelized sugar
+// Fresh Fruit Napoleon	
+ 
+// $6.95
+// Puff Pastry with pastry cream and seasonal fruit
+// Two Chocolate Mousse	
+ 
+// $6.95
+// White and Dark chocolate mousse with a raspberry coulis
+// White Chocolate Cheesecake	
+ 
+// $6.95
+// A lighter style of cheesecake with white chocolate finished with a raspberry coulis
+// Flourless Chocolate Torte	
+ 
+// $6.95
+// Homemade flourless chocolate torte served with raspberry puree and crème anglaise
+
+// Cakes
+// Cake Cutting Charge	
+ 
+// $1.95 Per Person
+// If we can't tempt you with our homemade desserts, we do allow your own cake to be served for the above person service charge.
+// Personalized Cake	
+ 
+// $39.95
+// 5 day lead time required (chocolate or white)
+// Wedding Cakes	
+ 
+//  Call
+
+ 
+// Rental Items
+// Decorations
+// Enhance the decor of your event with any of the following items.
+// Balloon Bouquet	
+ 
+// $12.95
+// Choose from Happy Anniversary, Happy Birthday or Generic
+// Candle Package	
+ 
+//  Call
+// Call for options
+// Flowers Bouquet	
+ 
+//  Call
+// Call for options
+
+// Audio/Visual Equipment
+// LCD Projector	
+ 
+// $50.00
+// InFocus 800x600 pixel
+// Projection Screen	
+ 
+// $35.00
+// Ceiling/Wall mount in specific locations (Outside retal required for tripod mounting)

--- a/server/views/banquets/venues.jade
+++ b/server/views/banquets/venues.jade
@@ -1,23 +1,65 @@
 ﻿extends ../../includes/layoutBanquet
 block banquetContent
-    h2 Venues
+    h2 Venues -- MORE IN COMMENTS
     
-    p Goal: View this file as a branch    
-    p Have you visited our restaurants before?
+//     Venues
 
-    p If not, we strongly encourage you to do so as soon as possible so you can determine whether our dining rooms or patios
-        | will serve your needs.
+// Have you visited our restaurants before?
 
-    p Upstairs in Baily’s, we offer four separate rooms. The largest, the North Dining Room, is a well appointed room perfect for up to 50 people with facilities for audio visual presentations. The elegant Rotunda Dining Room offers an intimate setting with a double sided fireplace, high ceiling with a grand chandelier and draping curtains; it is perfect for parties up to 38 guests. The cozy South Dining Room is an excellent venue for parties up to 18 guests. Finally, the airy Balcony Dining Room overlooks Old Town Front Street and features the second side of the double sided fireplace and ceiling fans; the balcony seats up to 30 people. The rooms may be booked separately or together, and when the entire floor is booked, Baily’s can accommodate 136 guests.
+// If not, we strongly encourage you to do so as soon as possible so you can determine whether our dining rooms or patios will serve your needs.
 
-    p For a more casual dining experience Front Street Bar & Grill, on the ground floor, makes the Patio available for private parties for up 70 guests. The outdoor venue has brick lined planters, ceramic pots and an eclectic fountain. Suspended umbrellas keep the sun off your guests. On cooler nights numerous patio heaters provide warmth.
+// Upstairs in Baily’s, we offer four separate rooms. The largest, the North Dining Room, is a well appointed room perfect for up to 50 people with facilities for audio visual presentations. The elegant Rotunda Dining Room offers an intimate setting with a double sided fireplace, high ceiling with a grand chandelier and draping curtains; it is perfect for parties up to 38 guests. The cozy South Dining Room is an excellent venue for parties up to 18 guests. Finally, the airy Balcony Dining Room overlooks Old Town Front Street and features the second side of the double sided fireplace and ceiling fans; the balcony seats up to 30 people. The rooms may be booked separately or together, and when the entire floor is booked, Baily’s can accommodate 136 guests.
 
-    p Daily each venue is open to the public. When you book an event we stop taking reservations and begin to turn business away. Food and beverage minimums are based on the amount of business that would be generated on a normal business day.
+// For a more casual dining experience Front Street Bar & Grill, on the ground floor, makes the Patio available for private parties for up 70 guests. The outdoor venue has brick lined planters, ceramic pots and an eclectic fountain. Suspended umbrellas keep the sun off your guests. On cooler nights numerous patio heaters provide warmth.
 
-    p On page 19 are several options to further enhance the decor of your event, including candles and audio/visual equipment.
+// Daily each venue is open to the public. When you book an event we stop taking reservations and begin to turn business away. Food and beverage minimums are based on the amount of business that would be generated on a normal business day.
 
-    p Our goal is to provide an environment that appeals to all senses. By doing so we are confident you will have a memorable event.
+// On page 19 are several options to further enhance the decor of your event, including candles and audio/visual equipment.
 
-    p Below are images of our different dining rooms and event venues. Each location can accomodate a different number of people.
-    
-    
+// Our goal is to provide an environment that appeals to all senses. By doing so we are confident you will have a memorable event.
+
+// Below are images of our different dining rooms and event venues. Each location can accomodate a different number of people.
+
+// *  December Holiday Pricing
+
+// North Dining Room	
+// North Dining Room
+// Capacity: 50 People
+//  	Normal	Holiday
+// Lunch:	$800	$1000
+// Dinner:	$1500	$1800
+// Dinner
+// Fri & Sat:	$1800	$2200
+// The Rotunda	
+// Rotunda
+// Capacity: 38 People
+//  	Normal	Holiday
+// Lunch:	$750	$1000
+// Dinner:	$1800	$2200
+// Dinner
+// Fri & Sat:	$2100	$2500
+// The Balcony	
+// Balcony
+// Capacity: 30 People
+//  	Normal	Holiday
+// Lunch:	$500	$600
+// Dinner:	$800	$1000
+// Dinner
+// Fri & Sat:	$1100	$1300
+// South Dining Room	
+// South Dining Room
+// Capacity: 18 People
+//  	Normal	Holiday
+// Lunch:	$300	$400
+// Dinner:	$400	$500
+// Dinner
+// Fri & Sat:	$500	$600
+// Front Street Bar & Grill Patio	
+// Front Street Bar & Grill Patio
+// Capacity: 70 People
+//  	Normal	Holiday
+// Lunch:	$1000	$1200
+// Dinner:	$1500	$1800
+// Dinner
+// Fri & Sat:	$2200	
+// $2500

--- a/server/views/dining/beer.jade
+++ b/server/views/dining/beer.jade
@@ -1,5 +1,168 @@
 extends ../../includes/layoutDining
 block diningContent
-   p Here is our beer list!
 
+    h1 Beers and More - MORE IN COMMENTS
+
+<!--
+Draught Beers - Lagers
+Coldest taps in town, ordered lighter to heavier in style and body. Draught sold by the 12 and 20 ounce glass.
+Dos Equis - Lager	
+ 
+$4.50  $6.50
+Stella Artois	
+ 
+$5.50  $7.50
+
+Draught Beer - Ales
+Shock Top - Belgian White	
+ 
+$4.50  $6.00
+Ballast Point - Pale Ale	
+ 
+$4.50  $6.50
+Elysian Superfuzz - Blood Orange Pale Ale	
+ 
+$4.50  $6.50
+Ironfire 51/50 IPA - India Pale Ale	
+ 
+$5.00  $7.00
+Ballast Point - Grapefruit Sculpin - West Coast IPA with Grapefruit	
+ 
+$6.50  $9.50
+Ironfire - Death Row Triple Chocolate Stout On Nitro - 12oz only	
+ 
+$7.00
+
+Lagers
+Bud Light	
+ 
+$5.50 16oz
+Bud Light Lime	
+ 
+$5.50 16oz
+Coors Light	
+ 
+$5.50 16oz
+Miller Lite	
+ 
+$5.50 16oz
+//Budweiser	 <-- Still causes and error for some reason
+ 
+$5.50 16oz
+Bud Light Platinum	
+ 
+$4.50
+Montejo - Czech Pilsener	
+ 
+$4.00
+Corona - Extra	
+ 
+$4.00
+Ironfire Nuhell - Helles Lager with New Zealand Hops	
+ 
+$13.50 22oz
+
+Ales
+Blue Moon	
+ 
+$4.50
+Fat Tire Amber Ale	
+ 
+$9.00 22oz
+Kona Fire Rock Pale Ale	
+ 
+$4.00
+Chimay Triple White	
+ 
+$19.00 750ml
+Leffe Brown - Belgian Abbey Beer	
+ 
+$4.50
+Omission - Northwest Style IPA - Gluten Free	
+ 
+$5.00
+Ballast Point Sculpin IPA	
+ 
+$16.00 22oz
+Green Flash - Hop Head Red	
+ 
+$4.50
+Ironfire DOA (Dead On Arrival) - Double IPA	
+ 
+$15.00 22oz
+Ironfire Judge, Jury, and Executioner - Triple IPA	
+ 
+$15.00 22oz
+Chimay Premier Red	
+ 
+$17.00 750ml
+Chimay Grand Reserve Blue	
+ 
+$20.00 750ml
+Ironfire Vicious Disposition - Imperial Porter w local avocado honey	
+ 
+$16.00 22oz
+Ironfire Six Killer - Arabica coffee bean & Hazelnut Stout	
+ 
+$12.00 22oz
+
+Ciders & Lambics - Fruit Beers
+Angry Orchard - Crisp Apple	
+ 
+$5.00
+Lindemans Framboise (Raspberry) Lambic	
+ 
+$13.50
+Lindemans Peche (Peach) Lambic	
+ 
+$13.50
+
+Non-Alcoholic Beer
+Beck's N/A	
+ 
+$3.50
+Buckler N/A	
+ 
+$3.50
+St. Pauli Girl N/A	
+ 
+$3.50
+
+Drinks for All Ages
+Bottomless Soft Drinks	
+ 
+$2.50
+Shirley Temple, Roy Rodgers	
+ 
+$2.95
+Red Bull	
+ 
+$4.50
+San Pelligrino Water (Sparkling)	
+ 
+$4.95 500ml
+Juice (Cranberry, Orange, Lemonade and Apple)	
+ 
+$2.95
+Strawberry Lemonade	
+ 
+$3.95
+Root Beer Float	
+ 
+$4.75
+Milk, Chocolate Milk, Hot Chocolate	
+ 
+$3.50
+
+Tea and Coffee
+Bottomless Iced Tea (Regular or Tropical)	
+ 
+$2.50
+Hot Tea (Assorted Varieties)	
+ 
+$2.95
+//Coffee <-- Still causes and error for some reason	
+ 
+$2.95
+--!>
 

--- a/server/views/dining/cocktails.jade
+++ b/server/views/dining/cocktails.jade
@@ -1,5 +1,57 @@
 extends ../../includes/layoutDining
 block diningContent
-    h1 Hello world
-    p Here is our specialty cocktails list! Try a cocktail.
+    h1 Cocktails -- MORE IN COMMENTS
+    
+<!--
+Specialty Drinks
 
+Specialty Drinks
+Baily’s Signature Margarita	
+ 
+$9.00
+Cuervo Tradicional Tequila, Grand Gala, pomegranate liqueur, and citrus juices on the rocks with pomegranate sugar rim
+Front Street Margarita	
+ 
+$9.00
+Cuervo Tradicional Tequila, fresh citrus juices and a splash of Grand Gala. Served on the rocks with a salt rim
+Cupid's Kiss	
+ 
+$9.00
+Smirnoff Vanilla Vodka, Godiva White Chocolate Liqueur, and raspberry liqueur, shaken and served up in a sugar rimmed cocktail glass
+Gingered Pear Martini	
+ 
+$11.00
+Grey Goose La Poire Vodka, Stirrings Ginger Liqueur, a splash of Pear Liqueur and fresh lemon juice. Shaken and served up in a cocktail glass with lemon twist
+Quadruple Berry Cosmo Martini	
+ 
+$8.00
+Smirnoff Blueberry Vodka, splash of Chambord, cranberry juice and strawberry sugar rim
+Hop, Skip and Go Naked	
+ 
+$8.50
+Craft Beer & Vodka cocktail made with our draught Ballast Point Sculpen IPA, Smirnoff Citrus Vodka and grapefruit juice, garnished with a lime wedge
+Baily’s Rum Runner	
+ 
+$10.00
+Meyer's Platinum Rum, made tropically delicious with splashes of Blackberry Brandy and Creme de Banana, shaken with pineapple & orange juices, and a float of Meyer's Dark Rum. Served on the rocks and garnished with a lime wheel and a cherry
+Baily’s Mardi Gras Cocktail	
+ 
+$9.50
+Captain Morgan Original Spiced Rum, pineapple & orange juices with a float of Amaretto. Served on the rocks and garnished with a lime wheel
+Apple Whiskey Sour	
+ 
+$7.50
+Mickey Finn Apple Whiskey, lemon juice, and our gourmet sweet & sour. Shaken and served over ice, garnished with a Maraschino cherry
+Pomegranate Lemon Drop	
+ 
+$8.00
+Pomegranate and Citrus Smirnoff Vodkas, lemonade, and a splash of fresh lemon juice. Shaken and served up in a cocktail glass with pomegranate sugared rim
+Holland Mule	
+ 
+$9.00
+Nolet Silver Gin with Fever Tree Ginger Beer over ice and a squeeze of fresh lime
+Moscow Mule	
+ 
+$8.50
+Ketel One Vodka with Fever Tree Ginger Beer over ice and a squeeze of fresh lime
+--!>

--- a/server/views/dining/spirits.jade
+++ b/server/views/dining/spirits.jade
@@ -2,4 +2,452 @@
    Created by patterncoder on 5/12/2015.
 extends ../../includes/layoutDining
 block diningContent
-    p Here is our spirits list!
+    h1 Here is our spirits list! -- MORE IN COMMENTS
+    
+<!--
+Liquor
+
+Well Liquor
+We are proud of the liquors served from our well which are considered call liquors in many othe establishments. When you order a generic cocktail from our mixologist know that it is made with one or more of the following.
+Smirnoff Vodka	
+ 
+$5.00
+Tanqueray Gin	
+ 
+$5.50
+Cuervo Silver	
+ 
+$5.50
+Myer's Platinum	
+ 
+$5.00
+Seagram's 7 Crown	
+ 
+$5.00
+J & B Scotch	
+ 
+$5.50
+Jaques Cardin Brandy	
+ 
+$5.50
+Cinzano Sweet Vermouth	
+ 
+Cinzano Dry Vermouth	
+ 
+
+Vodka
+Absolut Peppar
+
+$6.00 
+Belvedere
+ 
+$8.00
+Belvedere 1X - 100 Proof	
+ 
+$9.00
+Belvedere Lemon Tea	
+ 
+$8.00
+Ciroc
+ 
+$7.75
+Ciroc Peach	
+ 
+$7.75
+Ciroc Red Berry	
+ 
+$7.75
+Grey Goose	
+ 
+$10.00
+Grey Goose La Poire	
+ 
+$10.00
+Jerermiah Weed - Sweet Tea	
+ 
+$7.00
+Kettle One	
+ 
+$7.00
+Kettle One Citroen	
+ 
+$7.00
+Kettle One Orange	
+ 
+$7.00
+Smirnoff Apple	
+ 
+$5.50
+Smirnoff Blueberry	
+ 
+$5.50
+Smirnoff Cinna-Sugar	
+ 
+$5.50
+Smirnoff Coconut	
+ 
+$5.50
+Smirnoff Cherry	
+ 
+$5.50
+Smirnoff Citrus	
+ 
+$5.50
+Smirnoff Orange	
+ 
+$5.50
+Smirnoff Pear	
+ 
+$5.50
+Smirnoff Pomegranate	
+ 
+$5.50
+Smirnoff Raspberry	
+ 
+$5.50
+Smirnoff Root Beer Float	
+ 
+$5.50
+Smirnoff Toasted Marshmallow	
+ 
+$5.50
+Smirnoff Vanilla	
+ 
+$5.50
+Smirnoff Watermelon	
+ 
+$5.50
+Smirnoff Whipped Cream	
+ 
+$5.50
+
+Gin
+Bombay Sapphire	
+ 
+$7.50
+Gordon's	
+ 
+$5.50
+Nolet's Silver Dry Gin	
+ 
+$7.50
+Tanqueray #10	
+ 
+$8.00
+
+Tequila
+Don Julio 70th Anejo Blanco	
+ 
+$12.00
+Don Julio 1942	
+ 
+$15.00
+Don Julio Anejo	
+ 
+$11.50
+Don Julio Blanco	
+ 
+$9.50
+Don Julio Reposado	
+ 
+$11.00
+
+Rum
+10 Cane	
+ 
+$8.50
+Bacardi Limón	
+ 
+$7.50
+Bacardi Silver	
+ 
+$7.00
+Bacardi 151	
+ 
+$9.00
+Captain Morgan Lime Bite	
+ 
+$5.00
+Captain Morgan Mango	
+ 
+$6.00
+Captain Morgan Passionfruit	
+ 
+$6.00
+Captain Morgan Spiced	
+ 
+$5.50
+Captain Morgan Spiced 100	
+ 
+$6.00
+Malibu Coconut	
+ 
+$6.00
+Myer's Original Dark	
+ 
+$6.00
+
+Whiskey
+Bulleit Bourbon	
+ 
+$6.50
+Bulleit Rye	
+ 
+$6.50
+Bushmills
+ 
+$5.75
+Bushmills Black Bush	
+ 
+$7.00
+Bushmills Honey	
+ 
+$6.00
+Cabin Fever Maple Whisky	
+ 
+$7.00
+Crown Royal	
+ 
+$7.00
+Crown Royal Reserve	
+ 
+$10.00
+Gentleman Jack	
+ 
+$9.00
+Jack Daniel's	
+ 
+$7.00
+Jack Daniel's Honey	
+ 
+$7.00
+Jameson
+ 
+$6.50
+Jim Beam	
+ 
+$5.50
+Maker's Mark	
+ 
+$7.00
+Michael Collins Blended	
+ 
+$6.25
+Michael Collins Singlemalt	
+ 
+$7.50
+Seagram's Dark Honey	
+ 
+$5.50
+Seagram's VO	
+ 
+$5.50
+
+Scotch Whiskey
+Ardbeg 10 Year	
+ 
+$10.00
+Buchanan's 12 Year	
+ 
+$10.00
+Cutty Sark	
+ 
+$6.00
+Dewar's White	
+ 
+$8.00
+Glenlivet 12 Year	
+ 
+$8.00
+Glenmorangie 10 Year	
+ 
+$8.50
+Johnnie Walker Black	
+ 
+$8.00
+Johnnie Walker Blue	
+ 
+$25.00
+Johnnie Walker Gold	
+ 
+$14.50
+Johnnie Walker Green	
+ 
+$15.00
+Laphroaig 10 Year	
+ 
+$10.00
+Oban 14 Year	
+ 
+$13.00
+Singleton Single Malt	
+ 
+$6.00
+
+Cognac
+Hennessy VS	
+ 
+$8.00
+Hennessy Black	
+ 
+$9.00
+Hennessy VSOP	
+ 
+$10.00
+Hennessy XO	
+ 
+$27.00
+Navan Vanilla	
+ 
+$10.00
+
+Fortified Wine
+Harveys Bristol Cream	
+ 
+$5.50
+Paul Masson Brandy	
+ 
+$5.50
+
+Proprietary Liqueurs
+Amaretto Disaronno	
+ 
+$6.00
+B & B	
+ 
+$8.00
+Bailey's Irish Cream	
+ 
+$6.00
+Bailey's Vanilla Cinnamon	
+ 
+$6.00
+Barenjager
+ 
+$6.00
+Campari
+
+$6.00
+Chambord
+
+$7.50
+Drambuie
+ 
+$10.00
+Frangelico
+ 
+$8.00
+Galliano
+ 
+$6.00
+Godiva Dark Chocolate
+ 
+$7.00
+Godiva White Chocolate
+ 
+$7.00
+Goldschlager
+ 
+$7.00
+Grand Marnier
+ 
+$8.50
+Grand Marnier 150 Year
+ 
+$20.00
+Grand Marnier Titanium
+ 
+$10.00
+Harlem
+ 
+$5.00
+Hpnotiq
+ 
+$7.00
+Kahlua
+ 
+$6.00
+Licor 43
+ 
+$6.00
+Midori
+ 
+$6.00
+Nuvo Sparkling Liqueur - Classic or Peach Cobbler
+ 
+$11.00
+Qream Peach
+ 
+$7.00
+Qream Strawberry
+ 
+$7.00
+Rumple Minze
+ 
+$6.00
+Rumple Minze Lime	
+ 
+$4.00
+Romana Sambuca
+ 
+$6.50
+Southern Comfort	
+ 
+$6.00
+Tia Maria
+ 
+$6.50
+Tuaca
+ 
+$6.00
+
+Cordials
+Our DeKuyper and other noted brand of cordials are used for the numerous cocktails made in our bar.
+Anisette
+ 
+Blackberry
+ 
+Butter Shots	
+ 
+Cheri Beri
+ 
+Cinnanmon Schnapps
+ 
+Crème de Banana
+ 
+Crème de Cacao Dark
+ 
+Crème de Cacao White
+ 
+Crème de Cassis
+ 
+Crème de Menthe Green
+ 
+Crème de Menthe White
+ 
+Curacao Blue
+ 
+Espresso
+ 
+Island Blue
+ 
+Peachtree
+ 
+Peppermint 100 Proof
+ 
+Pineapple
+ 
+Razzamatazz
+ 
+Rootbeer
+
+Sloe Gin
+ 
+Sour Apple
+ 
+Triple Sec
+ 
+Watermelon
+ 
+
+ --!>

--- a/server/views/dining/wine.jade
+++ b/server/views/dining/wine.jade
@@ -2,4 +2,454 @@
    Created by patterncoder on 5/12/2015.
 extends ../../includes/layoutDining
 block diningContent
-    p Here is our wine list!
+    
+    p Here is our wine list! -- MORE IN COMMENTS
+    
+//    Our wine list below features wines hand picked by Kim Baily.  Wine that are available by the glass have two prices listed.  Our servers are pleased to assist you with wine selections.
+ 
+// Wine List
+
+// Our winelist changes frequently.
+// Sauvignon Blanc
+// R2
+// 2012
+// Baily Vineyard & Winery - Montage - Savignon Blanc/Sémillon - Temecula
+// $32.00
+// $8.50
+// R2
+// 2013
+// Makara - Marlborough, New Zealand
+// $30.00
+// $7.50
+// R2
+// 2013
+// Matua Valley - Marlborough, New Zealand
+// $28.00
+// R2/B309
+// 2013
+// Sterling - Napa Valley
+// $23.00
+// Chardonnay
+// R1
+// 2012
+// Chalone Vineyard - Monterey County
+// $26.00
+// R1
+// 2010
+// Erik Turner - Epic Day - Unoaked - Temecula
+// $30.00
+// R1/B308
+// 2012
+// Flora Springs - Napa Valley
+// $32.00
+// R1/B307
+// 2013
+// Flowers - Sonoma Coast
+// $69.00
+// R1
+// 2013
+// Louis Latour - Ardèche - Côteaux de l'Ardèche, France
+// $24.00
+// $7.00
+// R1
+// 2013
+// Sterling - Vintner's Collection - Central Coast
+// $28.00
+// $8.00
+// R1
+// 2013
+// Talbott - Kali Hart - Estate Grown, Monterrey
+// $32.00
+// $9.00
+// Riesling
+// R2
+// 2013
+// Baily Vineyard & Winery - Dry Riesling - Temecula
+// $26.00
+// $7.00
+// R2/B204
+// 2011
+// BV - Coastal Estates Riesling - California
+// $22.00
+// R2
+// 2008
+// Trimbach - Riesling (Dry) - Alsace, France
+// $37.00
+// Other White
+// R2
+// 2012
+// Beaulieu Vineyard - Muscato - Coastal Estates - California
+// $26.00
+// $7.00
+// R2
+// 2010
+// Cherry on Top - Muscat, Riesling, Gewurztraminer - Sweet Blend
+// $23.00
+// R2
+// 2012
+// Luccio - Moscato d’Asti - Piedmont, Italy
+// $24.00
+// R2
+// 2013
+// Luna Vineyards - Pinot Grigio - Napa Valley
+// $28.00
+// $7.50
+// R2/B310
+// 2013
+// Ponzi Vineyards - Pinot Gris - Willamette Valley, Oregon
+// $34.00
+// Rose
+// R2
+// 2012
+// Baily Vineyard & Winery - Rose of Sangiovese (Dry) - Temecula
+// $24.00
+// $6.50
+// R2/B203
+// 2012
+// Warrant - Wick'd Rosé (Sweet) - Cab Sauv & Cab Franc
+// $29.00
+// Cabernet Sauvignon
+// SRB
+// 2011
+// Baily Vineyard & Winery - Temecula
+// $44.00
+// $11.00
+// C-S48
+// 2008
+// Beaulieu Vineyard - George de Latour Private Reserve - Napa Valley
+// $149.00
+// C301
+// 2010
+// Beaulieu Vineyard - George de Latour Private Reserve - Napa Valley
+// $120.00
+// C308
+// 2011
+// Beaulieu Vineyard - Rutherford
+// $61.00
+// C307
+// 2011
+// Caymus - Napa Valley
+// $115.00
+// C201
+// 2012
+// Caymus - 40th Anniversary, Napa Valley
+// $119.00
+// C-S69
+// 2004
+// Caymus - Special Selection - Napa Valley
+// $240.00
+// C2
+// 2010
+// Caymus - Special Selection - Napa Valley
+// $225.00
+// C501
+// 2012
+// Daou Vineyards - Paso Robles
+// $42.00
+// C1
+// 2010
+// Dominus Estate - Napa Valley
+// $275.00
+// C401
+// 2010
+// Groth - Oakville, Napa Valley
+// $107.00
+// C405
+// 2010
+// Hewitt - Rutherford, Napa Valley
+// $125.00
+// C-S67
+// 2009
+// Hundred Acre - Ark Vineyard - Howell Mountain, Napa Valley
+// $400.00
+// C305
+// 2009
+// Liparita - Oakville, Napa Valley
+// $90.00
+// C306
+// 2012
+// ONEHOPE - California - 50% profits Help Children with Autism
+// $24.00
+// SRB
+// 2012
+// Paripaso - Paso Robles - California
+// $30.00
+// $8.00
+// S46
+// 2002
+// Paul Hobbs - Beckstoffer To Kalon Vineyard - Oakville, Napa
+// $249.00
+// C206
+// 2011
+// Provenance - Rutherford, Napa Valley
+// $69.00
+// C304
+// 2013
+// Uppercut - Napa Valley
+// $34.00
+// $9.50
+// Meritage
+// C-SRB
+// 2010
+// Baily Vineyard & Winery - Temecula
+// $65.00
+// C304
+// 2010
+// Beaulieu Vineyard - Tapestry - Rutherford, Napa Valley
+// $69.00
+// B304
+// 2011
+// if you see kay - Cabernet, Petite Verdot & Primitivo - Lazio, Italy
+// $40.00
+// C-S71
+// 2010
+// Newton - Claret - Napa County
+// $42.00
+// C101
+// 2000
+// Niebaum Coppola - Rubicon - Rutherford, Napa Valley
+// $160.00
+// C1
+// 2009
+// Opus One - Napa Valley
+// $300.00
+// C404
+// 2011
+// Sterling - Vintner's Collection - Central Coast
+// $26.00
+// Merlot
+// B601
+// 2012
+// Sterling - Napa Valley
+// $32.00
+// $9.00
+// B609
+// 2009
+// Waterbrook - Reserve - Columbia Valley, Washington
+// $42.00
+// Other Red
+// B407
+// 2011
+// Baily Vineyard & Winery - Cabernet Franc - Temecula
+// $35.00
+// B?607
+// 2011
+// Baily Vineyard & Winery - Malbec - Temecula
+// $34.00
+// B703
+// 2011
+// Baily Vineyard & Winery - M&M - 50% Merlot & 50% Malbec - Temecula
+// $34.00
+// $8.50
+// B504
+// 2011
+// Baily Vineyard & Winery - Sangiovese - Unoaked - Temecula
+// $34.00
+// $9.00
+// B606
+// 2009
+// Beaulieu Vineyard - Beaurouge - Red Blend - Rutherford, Napa Valley
+// $49.00
+// B605
+// 2014
+// George Duboeuf - Beaujolais - Villages Nouveau, France
+// $27.00
+// B405
+// 2008
+// la Maialina - Chianti Classico - Greve, Italy
+// $32.00
+// B401
+// 2010
+// La Tarasque - Old Vine Grenache Blend - Cotes Du Rhone, France
+// $30.00
+// B604
+// 2008
+// Numanthia - Termes - Tinto de Toro - Toro, Spain
+// $35.00
+// B701
+// 2013
+// Portillo - Malbec - Valle de Uco - Mendoza, Argentina
+// $29.00
+// B704
+// NV
+// Rosatello - Rosso - Sweet Red Blend, Italy
+// $24.00
+// SBR
+// 2000
+// Ruffino - Romitorio di Santedame (Merlot & Colorino) - Italy
+// $59.00
+// B408
+// 2011
+// Tuck Beckstoffer - Melée - 90% Grenache & 10% Syrah, California
+// $65.00
+// B512
+// 2003
+// Vina Cobos by Paul Hobbs - Malbec - Marchiori Vineyard - Mendoza, Argentina
+// $140.00
+// B301
+// 2008
+// Zaca Mesa - Z Cuvée - Grenache, Mourvedre & Syrah, Santa Ynez
+// $36.00
+// Pinot Noir
+// B-SRB
+// 2012
+// Acacia - Napa Valley & Carneros
+// $38.00
+// B511
+// 2013
+// Acacia - Napa Valley & Carneros
+// $38.00
+// B509
+// 2013
+// Belle Gloss by Caymus - Meiomi - Monterey, Santa Barbara & Sonoma Counties
+// $47.00
+// B508
+// 2010
+// Boulder Bank by Nick Goldschmidt -  Marlborough - New Zealand
+// $42.00
+// B507
+// 2012
+// Cameron Hughes - Lot 425 - Central Coast
+// $32.00
+// $8.50
+// B404
+// 2006
+// Chalone Vineyard - (375mL) - Estate
+// $24.00
+// B501
+// 2013
+// Cherry Pie - Cherry Tart, Sonoma, Monterey & Santa Barbara Co
+// $36.00
+// B506
+// 2010
+// Domaine Faiveley - Clos des Myglands - Mercurey 1er Cru - Burgundy
+// $60.00
+// Zinfandel
+// B408
+// 2012
+// Beran by Caymus - California
+// $36.00
+// B412
+// 2012
+// Bradford Mountain - Dry Creek Valley
+// $30.00
+// B409
+// 2011
+// ONEHOPE - California - 50% profits go to Support Our Troops
+// $28.00
+// B410
+// 2011
+// Rosenblum - Sonoma
+// $32.00
+// $8.50
+// B411
+// 2009
+// Rosenblum - Rockpile - Rockpile Road Vineyard, Sonoma
+// $65.00
+// Syrah
+// B306
+// 2010
+// Château Tanunda - Shiraz - Grand Barossa - Australia
+// $34.00
+// B305
+// NV
+// Erik Turner - Rocker Red - Temecula
+// $32.00
+// BSBR
+// 2011
+// Layer Cake - Shiraz - South Australia
+// $30.00
+// B406
+// 2013
+// Layer Cake - Shiraz - South Australia
+// $30.00
+// B201
+// 2011
+// Two Hands - Angel's Share Shiraz - McLaren Vale, Australia
+// $49.00
+// Dessert Wine
+// S29-32
+// NV
+// Rosenblum - Desiree - Chocolate - Alameda, California
+// $36.00
+// $9.00
+// Dessert Wine - Fortified
+// (3oz. Glass Pour)
+// CART/S10
+// 2009
+// Baily Vineyard & Winery - Vintage Port - Temecula
+// $56.00
+// $15.00
+// S38
+// 1997
+// C&E Sandeman - Port - Vau Vintage (375ml) - Portugal
+// $63.00
+// CART
+// NV
+// Cockburn's - Special Reserve Port - Portugal
+// $6.00
+// CART/S14
+// NV
+// Cockburn's - Tawny Port - 10 Year - Portugal
+// $45.00
+// $6.00
+// CART/S41
+// 2006
+// Dows - Quinta Senhora da Ribeira - Portugal
+// $88.00
+// $14.00
+// CART
+// NV
+// Dows - Tawny Port - 20 Year - Portugal
+// $13.00
+// CART/S07
+// NV
+// Dows - Trademark Reserve Port - Portugal
+// $45.00
+// $7.00
+// S23
+// NA
+// South Coast Winery - Black Jack Port - Temecula
+// $50.00
+// Sparkling Wine
+// R4/B2
+// NV
+// Domaine Chandon - Blanc de Noir - California
+// $43.00
+// R4/B1
+// NV
+// Domaine Chandon - Brut Classic - California
+// $43.00
+// BAR
+// NV
+// Domaine Chandon - Rose - California (187ml)
+// $11.00
+// R3
+// 2003
+// Dom Pérignon - Brut - Epernay, France
+// $249.00
+// BAR
+// NV
+// Moet & Chandon - Imperial (White Star) - Epernay, France (187ml)
+// $18.00
+// BAR
+// NV
+// Segura Viudas - Brut (187ml) - Spain
+// $8.00
+// R3/B2
+// NV
+// South Coast Winery - Sparkling Syrah - Ruby Cuvée - Temecula
+// $42.00
+// R3/B1
+// NV
+// Stellina di Notte - Prosecco - Italy
+// $26.00
+// R4
+// NV
+// Toad Hollow - Risqué - Languedoc, France
+// $27.00
+// R3
+// NV
+// Veuve Clicquot - Yellow Label Brut - Reims, France
+// $99.00
+// Baily’s is very proud of our wine list selections and encourage you to seek out a wine that will match your tastes. However, if you care to bring in your own bottle of wine that does not appear on our list there will be a $15.00 corkage fee per 750ml bottle.

--- a/server/views/music/booking.jade
+++ b/server/views/music/booking.jade
@@ -1,6 +1,6 @@
 ﻿extends ../../includes/layoutMusic
 block musicContent
-    p This is page for information about booking your band.
+    p This is page for information about booking your band. -- COULD NOT FIND RELATABLE PAGE
 
 
 

--- a/server/views/music/music.jade
+++ b/server/views/music/music.jade
@@ -1,6 +1,6 @@
 ﻿extends ../../includes/layoutMusic
 block musicContent
-    p This is the music home page.
+    p This is the music home page. -- COULD NOT FIND RELATABLE PAGE
 
 
 

--- a/server/views/nightclub/bottleservice.jade
+++ b/server/views/nightclub/bottleservice.jade
@@ -1,4 +1,87 @@
 ﻿extends ../../includes/layoutNightclub
 block nightclubContent
-    p Here is the nightclub bottle service information!
+    p Here is the nightclub bottle service information! -- MORE IN COMMENTS
+    
+//     VIP Bottle Service Menu
+
+// Unless noted, bottle service includes a 750ml bottle with appropriate garnishes and mixers. Energy drinks are available for an addtional charge. Price includes cover charge for six people. Each addtional person is $5.00. Second price listed is for New Year's Eve and includes cover charge for six people, each additional person is $20. Call 951-676-9567 to make reservations.
+// Vodka
+// Kettle One	
+ 
+// $180.00  $280.00 NYE
+// Belvedere	
+ 
+// $175.00  $275.00 NYE
+// Ciroc 1000ml	
+ 
+// $225.00  $325.00 NYE
+// Grey Goose	
+ 
+// $230.00  $330.00 NYE
+// Purity	
+ 
+// $235.00  $335.00 NYE
+
+// Cognac
+// Hennessy Black	
+ 
+// $195.00  $295.00 NYE
+// Hennessy VS 1000ml	
+ 
+// $235.00  $335.00 NYE
+// Hennessy VSOP	
+ 
+// $245.00  $345.00 NYE
+
+// Whiskey
+// Crown Royal 1000ml	
+ 
+// $205.00  $305.00 NYE
+// Jack Daniel's 1000ml	
+ 
+// $210.00  $310.00 NYE
+
+// Scotch Whiskey
+// Buchanan's 12 Year	
+ 
+// $200.00  $300.00 NYE
+// Johnnie Walker Black 1000ml	
+ 
+// $220.00  $320.00 NYE
+
+// Rum
+// Captain Morgan Spiced	
+ 
+// $175.00  $275.00 NYE
+
+// Gin
+// Tanqueray Gin 1000ml	
+ 
+// $195.00  $295.00 NYE
+
+// Tequila
+// Don Julio Anejo	
+ 
+// $245.00  $345.00 NYE
+// Don Julio Blanco	
+ 
+// $210.00  $310.00 NYE
+// Don Julio Reposado	
+ 
+// $230.00  $330.00 NYE
+
+// Sparkling Wine
+// Domaine Chandon - Sparkling Wine - Blanc de Noir - California - NV	
+ 
+// $170.00  $270.00 NYE
+// Domaine Chandon - Sparkling Wine - Brut Classic - NV	
+ 
+// $170.00  $270.00 NYE
+// Veuve Clicquot - Yellow Label Brut - Reims, France - NV	
+ 
+// $220.00  $320.00 NYE
+// Moet & Chandon - Cuvee Dom Perignon - Epernay, France - 2000	
+ 
+// $450.00  $550.00 NYE
+
 

--- a/server/views/nightclub/menu.jade
+++ b/server/views/nightclub/menu.jade
@@ -1,4 +1,4 @@
 ﻿extends ../../includes/layoutNightclub
 block nightclubContent
-    p Here is the nightclub menu information!
+    p Here is the nightclub menu information! -- NO RELATABLE PAGE FOUND
 

--- a/server/views/nightclub/nightclub.jade
+++ b/server/views/nightclub/nightclub.jade
@@ -1,4 +1,42 @@
 ﻿extends ../../includes/layoutNightclub
 block nightclubContent
-    p Here is the general nightclub information!
+    p Here is the general nightclub information! -- MORE IN COMMENTS
 
+// eleven after dark
+// The Hottest Nightclub in the I.E. open every Friday and Saturday.
+// 21 years and older 
+// Top DJs playing the best music!
+// Upscale, Sophisticated, Fun, Trendy, & Full of Energy
+// Huge Outdoor Patio & Courtyard Areas
+// Dress To Impress
+// Private VIP Booths & Bottle Service
+// Party Packages Available
+// Free before 10pm $5 cover charge after on weekends
+// Info & Reservations 951-676-9567
+// Friday Night
+
+// 10pm - Close: The band ends at 9:30pm and the Residents DJs  Ruffnek, B-Rythm or Vince West start the dance party at 10pm. Come see what your friends and neighbors ane talking about, and enjoy the hottest club in the Inland Empire/North San Diego County at Eleven After Dark! The rotating hot local DJs mix the very best music from old to new with a touch of your favorite classics! 
+// ***After Hours Latin Lounge Upstairs 11pm until close every Friday Night***
+// Two storys, two DJs &  dance floors, three full bars...
+
+// Saturday Night
+
+// 10pm - Close: Residents DJs Ruffnek, B-Rythm Ayeena & Vince West play the hottest music weekly!  Come see why people are talking about Saturday Nights at Eleven After Dark! Spinning the best of Mashup, Classic Rocks, Old School, and Top 40 music!
+// ***After Hours Latin Lounge Upstairs 11pm until close every Saturday Night***
+// Two storys, two DJs &  dance floors, three full bars...
+
+// Follow us "@11AfterDark" on Twitter & "Baily's Nightclub" Facebook page for events, contests, specials, and more...
+// The Details
+
+// Must be 21 years or older to enter the club 
+// Valid ID Required: State Issued Drivers License | State Issued Identification Card | Military Identification | Printed Passport (expired identification with renewal paperwork is not acceptable)
+// Dress Code
+// Gentlemen: Must wear Collared Shirt & Closed Toe Shoes - No Baseball Caps, Shorts, Flip Flops
+// Ladies: Dress to Impress
+// HOT Latin Nights at Baily's!
+ 
+
+ 
+ 
+// Upcoming Events:
+ 

--- a/server/views/nightclub/partypackage.jade
+++ b/server/views/nightclub/partypackage.jade
@@ -1,4 +1,24 @@
 ﻿extends ../../includes/layoutNightclub
 block nightclubContent
-    p Here is the nightclub party package information!
+    p Here is the nightclub party package information! -- MORE IN COMMENTS
+    
+//     Parties
+// Includes:
+
+// Cover charge
+// Hors d' Oeuvres
+// Dedicated Space
+// Beverage Package
+// Cocktail Server 
+// Menu
+
+// Vegetable crudite, fruit and cheese
+// Irish Nacho Buffet 
+// Beverage Package – $10 beverage credit or 2 selections per person from below 
+
+// Selection of Aluminum Bottled Beers
+// Glass of House Red or White Wines
+// 1.25 oz of Well Vodka, Gin, or Tequila + Assorted Mixers
+// $25 per person
+// 12 Person Minimum
 


### PR DESCRIPTION
I added all the raw data I could find from the old site. I didn't want to mess with format until we have the style guide down, so all the old info is on the pages commented out so we can just uncomment and format the data Tuesday.

I also tried my hand at adding an additional button on the "banquets" drop down. There was no page available for "party add ons" from the old site. It seems to be working, and there is now a "party add on" page and working links. Sorry if i broke anything, but I learned a few things by trying it.