### PR TITLE
open table award was clipping over content in some resolutions

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -349,3 +349,13 @@ section.wines h3 {
   filter: blur(2px);
   opacity: 0.7;
 }
+.openTableDiners {
+  overflow: hidden;
+}
+.openTableContent {
+  margin: 0 auto;
+  display: table;
+}
+.radiusBorder5px {
+  border-radius: 3px;
+}

--- a/public/css/site.styl
+++ b/public/css/site.styl
@@ -384,3 +384,13 @@ section.wines h3
 .homeBackground
   filter blur(2px)
   opacity 0.7
+
+.openTableDiners
+  overflow hidden
+
+.openTableContent
+  margin 0 auto
+  display table
+
+.radiusBorder5px
+  border-radius 3px

--- a/server/includes/navDining.jade
+++ b/server/includes/navDining.jade
@@ -17,7 +17,7 @@
                 a(href="/dining/cocktails") Specialty Cocktails
             li
                 a(href="/dining/spirits") Spirits
-        
-        a(href="http://www.opentable.com/restaurant/profile/995851/reserve?rid=995851&restref=995851" class="ot-dc-badge ot-dc-badge--p")
 
-
+        div.openTableDiners
+            div.openTableContent
+                a(href="http://www.opentable.com/restaurant/profile/995851/reserve?rid=995851&restref=995851" class="ot-dc-badge ot-dc-badge--p")


### PR DESCRIPTION
The open table award widget was clipping over content in some resolutions. Added an overflow: hidden to prevent this. Working on trying to center widget when overflow happens, although this is proving to be difficult. I may have to change some bootstrap settings to prevent the nav sidebar from shrinking too far.