### PR TITLE
taking offline until https is fixed and SSL is generated on the server

### DIFF
--- a/public/js/banquetSubmit.js
+++ b/public/js/banquetSubmit.js
@@ -206,5 +206,5 @@ let banqSubForm = () => {
     //make submission alert.
     //alert("Thank You, we will be contacting you soon!");
 
-    return container;
+    //return container;
 };


### PR DESCRIPTION
Need to setup https on the server in order to get rid of the cross-origin error.
Could use HTTP, however even though the server will send out the email, the response which confirms the message was sent, is never displayed. This could cause the customer to continually press the submit button thinking the submission failed, or never started at all.

Taking this tool offline until further notice.