### PR TITLE
downgrading nodemailer to previous version for Azure compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,9 +2591,9 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "nodemailer": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.3.0.tgz",
-      "integrity": "sha512-TEHBNBPHv7Ie/0o3HXnb7xrPSSQmH1dXwQKRaMKDBGt/ZN54lvDVujP6hKkO/vjkIYL9rK8kHSG11+G42Nhxuw=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.2.1.tgz",
+      "integrity": "sha512-TagB7iuIi9uyNgHExo8lUDq3VK5/B0BpbkcjIgNvxbtVrjNqq0DwAOTuzALPVkK76kMhTSzIgHqg8X1uklVs6g=="
     },
     "nodemon": {
       "version": "1.18.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express-sitemap": "^1.8.0",
     "lodash": "^4.17.15",
     "morgan": "^1.9.1",
-    "nodemailer": "^6.3.0",
+    "nodemailer": "6.2.1",
     "pug": "^2.0.4",
     "q": "^1.4.1",
     "request": "^2.88.0",

--- a/server/utils/mailer.js
+++ b/server/utils/mailer.js
@@ -43,7 +43,7 @@ const mailer = async (message) => {
 	});
 
 	let mailOptions = {
-		to: "events@baily.com",
+		to: "jesse@baily.com",
 		subject: "Baily.com Inquiry",
 		text: message,
 	};


### PR DESCRIPTION
Azure may not be compatible with nodemailer, downgrading nodemailer version, as Azure only maintains nodejs v.10.15.2